### PR TITLE
change deployment types and number to support an estimated target of 2.5m ADU

### DIFF
--- a/aws-tools/config/autoscale.stage.json
+++ b/aws-tools/config/autoscale.stage.json
@@ -10,7 +10,7 @@
                 "internet-outbound",
                 "administrable"
             ],
-            "instance_type" : "m1.small"
+            "instance_type" : "c1.medium"
         },
         "load_balancers":
         [
@@ -19,7 +19,7 @@
             "diresworb-org"
         ],
         "subnet": "private",
-        "desired_capacity": 3
+        "desired_capacity": 8
     },
     {
         "launch_configuration": 
@@ -32,7 +32,7 @@
                 "internet-outbound",
                 "administrable"
             ],
-            "instance_type" : "m1.small"
+            "instance_type" : "c1.medium"
         },
         "load_balancers":
         [
@@ -51,7 +51,7 @@
                 "middleware-http",
                 "administrable"
             ],
-            "instance_type" : "m1.small"
+            "instance_type" : "c1.medium"
         },
         "load_balancers":
         [
@@ -72,14 +72,14 @@
                 "internet-outbound",
                 "administrable"
             ],
-            "instance_type" : "m1.small"
+            "instance_type" : "c1.medium"
         },
         "load_balancers":
         [
             "dbwrite"
         ],
         "subnet": "private",
-        "desired_capacity": 2
+        "desired_capacity": 3
     },
     {
         "launch_configuration": 


### PR DESCRIPTION
Methodology was to take this post: https://groups.google.com/forum/?fromgroups=#!searchin/mozilla.dev.identity/ADU$20load/mozilla.dev.identity/st_eL7kUpUw/hrOUUatl5i0J

I.E. at 3M ADU we run 4.41 load on 2.3Ghz 24 core procs - suggesting we need about 14 processors with 2.5 compute units each to hit 3m in amazon.

thoughts?
