### PR TITLE
Enable TLS 1.2 and related ciphersuites

### DIFF
--- a/aws-tools/apply_security_assurance_elb_ciphersuite_policy.py
+++ b/aws-tools/apply_security_assurance_elb_ciphersuite_policy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=35069456
+# Apply recommendation from https://wiki.mozilla.org/Security/Server_Side_TLS
 
 import boto.ec2.elb
 import sys

--- a/aws-tools/stack_control.py
+++ b/aws-tools/stack_control.py
@@ -79,6 +79,7 @@ def create_stack(region,
     conn_cw = boto.ec2.cloudwatch.connect_to_region(region)
     stack = {}
 
+    # Apply recommendation from https://wiki.mozilla.org/Security/Server_Side_TLS
     policy_attributes = {"ADH-AES128-GCM-SHA256": False,
                         "ADH-AES256-GCM-SHA384": False,
                         "ADH-AES128-SHA": False,


### PR DESCRIPTION
Enable most recent TLS protocol and related ciphersuite in load balancer.
I'm fairly confident that this will work, since the descriptions come from the AWS CLI. But it hasn't been properly tested.
