### PR TITLE
raise toobusy maximum_event_loop_lag to 1000ms

### DIFF
--- a/chef/cookbooks/persona-dbwrite/templates/default/opt/browserid/config/production.json.erb
+++ b/chef/cookbooks/persona-dbwrite/templates/default/opt/browserid/config/production.json.erb
@@ -15,6 +15,7 @@
   "bcrypt_work_factor": 12,
   "max_compute_processes": 0,
   "max_compute_duration": 10,
+  "maximum_event_loop_lag": 1000,
   "disable_primary_support": false,
   "enable_code_version": false,
   "default_lang": "en",

--- a/chef/cookbooks/persona-keysign/templates/default/opt/browserid/config/production.json.erb
+++ b/chef/cookbooks/persona-keysign/templates/default/opt/browserid/config/production.json.erb
@@ -15,6 +15,7 @@
   "bcrypt_work_factor": 12,
   "max_compute_processes": 0,
   "max_compute_duration": 10,
+  "maximum_event_loop_lag": 1000,
   "disable_primary_support": false,
   "enable_code_version": false,
   "default_lang": "en",

--- a/chef/cookbooks/persona-webhead/templates/default/opt/browserid/config/production.json.erb
+++ b/chef/cookbooks/persona-webhead/templates/default/opt/browserid/config/production.json.erb
@@ -16,6 +16,7 @@
   "bcrypt_work_factor": 12,
   "max_compute_processes": 0,
   "max_compute_duration": 10,
+  "maximum_event_loop_lag": 1000,
   "disable_primary_support": false,
   "enable_code_version": false,
   "default_lang": "en",


### PR DESCRIPTION
With respect to https://github.com/mozilla/persona/issues/4039 and https://github.com/mozilla/persona/issues/4027, we want to raise this threshold since tossing spurious errors back at users at low request volume isnt' useful.

/cc @gene1wood
