### PR TITLE
Enabling relay_log_purge

### DIFF
--- a/chef/cookbooks/persona-db/templates/default/etc/my.cnf.erb
+++ b/chef/cookbooks/persona-db/templates/default/etc/my.cnf.erb
@@ -67,7 +67,7 @@ log-bin                = mysql-bin
 server-id              = <%= @server_id %>
 sync_binlog            = 1
 log_slave_updates      = 1
-relay_log_purge        = 0
+relay_log_purge        = 1
 replicate-do-db        = browserid
 
 <% if node[:persona][:db][:mysql][:replication_type] != "master" and node[:persona][:db][:mysql]["master-host"] %>


### PR DESCRIPTION
so that MySQL purges old relay bin logs saving disk space.

We had 36GB of `mysqld-relay-bin.*` logs that were removed when this option was enabled (which had been filling our 50GB disks).

I want to get the db teams input on this.
