### PR TITLE
fix persona-db monitor.rb recipe to properly include persona-common::monitor

### DIFF
--- a/chef/cookbooks/persona-db/recipes/monitor.rb
+++ b/chef/cookbooks/persona-db/recipes/monitor.rb
@@ -6,6 +6,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+include_recipe "persona-common::monitor"
+
 for file in ["usr/local/nagios/libexec/check_mysql_innodb",
              "usr/local/nagios/libexec/check_mysql_percona_heartbeat"]
   cookbook_file "/#{file}" do


### PR DESCRIPTION
@gene1wood  does this seem right to you? this monitor recipe was failing before, but it seems to work with this change.
